### PR TITLE
Add @nogc nothrow to nk_command_delegate, nk_draw_command_delegate

### DIFF
--- a/source/bindbc/nuklear/macros.d
+++ b/source/bindbc/nuklear/macros.d
@@ -25,9 +25,11 @@ version (NK_ALL)
     version = NK_UINT_DRAW_INDEX;
 }
 
-alias nk_command_delegate = void delegate(const(nk_command)*);
-version(NK_INCLUDE_VERTEX_BUFFER_OUTPUT) {
-    alias nk_draw_command_delegate = void delegate(const(nk_draw_command)*);
+@nogc nothrow {
+    alias nk_command_delegate = void delegate(const(nk_command)*);
+    version(NK_INCLUDE_VERTEX_BUFFER_OUTPUT) {
+        alias nk_draw_command_delegate = void delegate(const(nk_draw_command)*);
+    }
 }
 
 pragma(inline, true) {


### PR DESCRIPTION
This fixes the signature mismatch error:
`bindbc\nuklear\macros.d(78,26): Error: @nogc function bindbc.nuklear.macros.nk_draw_list_foreach cannot call non-@nogc delegate block`