### PR TITLE
Make this package work with bindbc 0.2.x and 0.3.x

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -9,13 +9,13 @@ targetPath "lib"
 targetName "BindBC_nuklear"
 
 configuration "dynamic" {
-    dependency "bindbc-loader" version="~>0.2.1"
+    dependency "bindbc-loader" version=">=0.2.1 <0.4.0"
     copyFiles "lib/win32/nuklear.dll" platform="windows-x86"
     copyFiles "lib/win64/nuklear.dll" platform="windows-x86_64"
 }
 
 configuration "dynamicBC" {
-    dependency "bindbc-loader" version="~>0.2.1"
+    dependency "bindbc-loader" version=">=0.2.1 <0.4.0"
     subConfiguration "bindbc-loader" "yesBC"
     copyFiles "lib/win32/nuklear.dll" platform="windows-x86"
     copyFiles "lib/win64/nuklear.dll" platform="windows-x86_64"


### PR DESCRIPTION
this makes it so you can use bindbc-nuklear with other bindbc packages using bindbc-loader 0.3.x